### PR TITLE
feat: LoginButton a태그로 감싸 /login 페이지로 가도록 설정, Navbar에 로그인 버튼 분기처리

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,21 +1,26 @@
+import LoginButton from "./button/LoginButton";
+
 const NavBar = () => {
+  // const isLoggedIn = localStorage.getItem("isLoggedIn");
+
+  const isLoggedIn = "true";
+
   return (
-    <div className="flex h-[56px] w-full justify-between">
+    <div className="flex h-[62px] w-full justify-between items-center px-5">
       <img
         src="/public/icon/mbtipslogo.svg"
         alt="Logo"
-        className="ml-[20px]"
         width={110}
         height={31}
       />
 
-      <img
+      {isLoggedIn === "true" ? <LoginButton/> : <img
         src="/public/icon/people.svg"
         alt="Login Done"
         className="mx-auto mr-[20px]"
         width={24}
         height={24}
-      />
+      />}
     </div>
   );
 };

--- a/src/components/button/LoginButton.tsx
+++ b/src/components/button/LoginButton.tsx
@@ -1,8 +1,10 @@
 const LoginButton = () => {
   return (
-    <button className="border-[0.8px] border-gray-300 px-4 py-0.5 rounded-lg font-bold text-gray-600 text-sm">
+    <a href="/login">
+      <button className="w-[69px] h-[36px] border-[0.8px] border-gray-300 rounded-lg font-bold text-gray-600 text-md">
       로그인
-    </button>
+      </button>
+    </a>
   );
 };
 


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- LoginButton.tsx에 a태그를 감싸 누르면 "/login" 페이지로 가도록 했습니다.
- Navbar에서 로컬스토리지를 확인해 isLoggedIn이 "true"이면(로컬 스토리지에서는 문자열 값) 로그인 버튼이 보이도록 했습니다.

### :1234: #96 

### ❗️PR Point
- 없음

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/e00cf8e1-a875-417b-9b09-b5785cf34183)

