### PR TITLE
fix: MyInfo.tsx에서 Header 잘못 import 되고 있었던 부분 수정

### DIFF
--- a/src/pages/MyInfo.tsx
+++ b/src/pages/MyInfo.tsx
@@ -1,7 +1,6 @@
 
 import Header from "@/components/header/Header";
 import { useState } from "react";
-import Header from "@/components/Header";
 import ActionConfirmModal from "@/components/modal/ActionConfirmModal";
 import useAuthStore from "@/store/useAuthStore";
 import { useNavigate } from "react-router-dom";


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- [x] Could not load /Users/junjeong/Documents/Mbtips/src/components/Header (imported by src/pages/MyInfo.tsx) 에러가 나서 확인해보니 MyInfo.tsx에서 Header 컴포넌트를 import하는데 경로가 잘못되었습니다. 

### :1234: #168 

### ❗️PR Point
- 없음

### 📸 스크린샷
- 없음