### PR TITLE
fix: MainHeader 비로그인일 때 Profile.svg 뜨는 문제 개선

### DIFF
--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -3,7 +3,7 @@ import LoginButton from "../button/LoginButton";
 
 const MainHeader = ({isLoggedIn}: {isLoggedIn : boolean})=> {
   return (
-    <header className="bg-white flex h-[56px] w-full justify-between px-5">
+    <header className="bg-white flex h-[56px] w-full justify-between items-center px-5">
       <Link to="/" className="flex items-center">
       <img
         src="/public/icon/mbtipslogo.svg"

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -12,7 +12,7 @@ const MainHeader = ({isLoggedIn}: {isLoggedIn : boolean})=> {
         height={31}
       />
       </Link>
-      {isLoggedIn ? <LoginButton/> : <img
+      {!isLoggedIn ? <LoginButton/> : <img
         src="/public/icon/people.svg"
         alt="Login Done"
         className="mx-auto mr-[20px]"


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- [o] isLoggedIn이 falsy일 때 LoginButton을 return 해야되는데 반대로 했습니다 ㅎ 

### :1234: 이슈 번호
-  없음

### ❗️PR Point
- 없음

### 📸 스크린샷
