### PR TITLE
style: 홈페이지 내부 font가 360px일 때 줄바꿈 되는 문제 개선

### DIFF
--- a/src/components/StrokeBanner.tsx
+++ b/src/components/StrokeBanner.tsx
@@ -23,8 +23,9 @@ const StrokeBanner = () => {
         친구 정보를 저장하고 대화할 수 있어요
       </strong>
       <p className="mt-2 text-sm font-light text-gray-900">
-        로그인 시 기억하고 싶은 친구의 MBTI와 특징을 입력해서 빠르게 대화할 수
-        있어요
+        로그인 시 기억하고 싶은 친구의 MBTI와 특징을
+        <br />
+        입력해서 빠르게 대화할 수 있어요
       </p>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -30,14 +30,15 @@ body {
 
 main {
   @media screen and (min-width: 360px) {
+    font-size: 14px;
     width: 360px;
-    
   }
   @media screen and (min-width: 375px) {
+    font-size: 16px;
     width: 375px;
-    
   }
   @media screen and (min-width: 500px) {
+    font-size: 16px;
     width: 500px;
   }
 }
@@ -55,7 +56,6 @@ button:hover {
 }
 
 @keyframes pulse-custom {
-
   0%,
   100% {
     transform: scale(1);


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- 홈페이지에 StrokeBanner 내부 font가 360px 일때에는 줄바꿈이 되는 문제가 발생햇고, 이를 14px로 조정하여 개선했습니다.

### :1234: #191 

### ❗️PR Point
- main 태그에 font-size를 반응형에 따라 기본 size를 주었습니다 360px일 때에만 14px이고 나머지는 16px입니다.,

### 📸 스크린샷
없음