### PR TITLE
feat : GA4 trackedpage 추가 및 click 이벤트 할당 (정준영 part)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,12 @@ const PageTracker = () => {
     { path: "/my-info", page: "내 정보" },
     { path: "/chat", page: "채팅방" },
     { path: "/select-info", page: "빠른 대화 설정" },
-    { path: "/select-info", page: "친구 저장" }
+    { path: "/mbti-test", page: "Mbti 테스트 첫 화면" },
+    { path: "/mbti-progress", page: "Mbti 테스트 진행중" },
+    { path: "/mbti-result", page: "Mbti 테스트 결과" },
+    { path: "/chat-recommend", page: "대화 주제 추천" },
+    { path: "/chat-tips", page: "대화 꿀팁" },
+    { path: "/chat-temporature", page: "대화 온도 측정" }
   ];
 
   useEffect(() => {

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -2,6 +2,7 @@ import { SetStateAction } from "react";
 import { useNavigate } from "react-router-dom";
 import { authInstance } from "@/api/axios";
 import { VirtualFriend } from "@/types/virtualFreind";
+import trackClickEvent from "@/utils/trackClickEvent";
 
 interface ProfileProps {
   info: VirtualFriend;
@@ -12,6 +13,7 @@ const Profile = ({ info, deleteIndex, setVirtualFriendList }: ProfileProps) => {
   const navigate = useNavigate();
 
   const handleDelete = async () => {
+    trackClickEvent("홈", "친구 - 삭제하기 버튼");
     const res = await authInstance.delete(
       `/api/virtual-friend/${info.virtualFriendId}`
     );
@@ -23,6 +25,7 @@ const Profile = ({ info, deleteIndex, setVirtualFriendList }: ProfileProps) => {
   };
 
   const handleNavigate = () => {
+    trackClickEvent("홈", "친구 - 대화 시작하기 버튼");
     navigate("/chat", {
       state: {
         mode: "virtualFriend",

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -13,7 +13,7 @@ const Profile = ({ info, deleteIndex, setVirtualFriendList }: ProfileProps) => {
   const navigate = useNavigate();
 
   const handleDelete = async () => {
-    trackClickEvent("홈", "친구 - 삭제하기 버튼");
+    trackClickEvent("홈", "친구 - 삭제");
     const res = await authInstance.delete(
       `/api/virtual-friend/${info.virtualFriendId}`
     );

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -25,7 +25,7 @@ const Profile = ({ info, deleteIndex, setVirtualFriendList }: ProfileProps) => {
   };
 
   const handleNavigate = () => {
-    trackClickEvent("홈", "친구 - 대화 시작하기 버튼");
+    trackClickEvent("홈", "친구 - 바로 대화하기");
     navigate("/chat", {
       state: {
         mode: "virtualFriend",

--- a/src/components/SubTitle.tsx
+++ b/src/components/SubTitle.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import trackClickEvent from "@/utils/trackClickEvent";
 
 const SubTitle = ({ mode }: { mode: "빠른대화" | "친구목록" }) => {
   const navigate = useNavigate();
@@ -16,6 +17,7 @@ const SubTitle = ({ mode }: { mode: "빠른대화" | "친구목록" }) => {
 
   const handleNavigate = () => {
     const type = mode === "빠른대화" ? "fastFriend" : "virtualFriend";
+    trackClickEvent("홈", "친구 추가 버튼");
     navigate("/select-info", { state: { type: type } });
   };
 

--- a/src/components/SubTitle.tsx
+++ b/src/components/SubTitle.tsx
@@ -17,7 +17,7 @@ const SubTitle = ({ mode }: { mode: "빠른대화" | "친구목록" }) => {
 
   const handleNavigate = () => {
     const type = mode === "빠른대화" ? "fastFriend" : "virtualFriend";
-    trackClickEvent("홈", "친구 추가 버튼");
+    trackClickEvent("홈", "친구 - 추가");
     navigate("/select-info", { state: { type: type } });
   };
 

--- a/src/components/button/ChatStartButton.tsx
+++ b/src/components/button/ChatStartButton.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { trackEvent } from "@/libs/analytics";
 
 type ChatStartButtonProps = {
@@ -8,13 +8,17 @@ type ChatStartButtonProps = {
 
 const ChatStartButton = ({ mode, mbti }: ChatStartButtonProps) => {
   const navigate = useNavigate();
+  const pathname = useLocation().pathname;
 
   const handleNavigate = () => {
     switch (mode) {
       case "go-fast":
         trackEvent("Click", {
-          page: "홈",
-          element: "빠른 대화 시작"
+          page: pathname === "/mbti-test-result" ? "바이럴 콘텐츠 결과" : "홈",
+          element:
+            pathname === "/mbti-test-result"
+              ? "대화 시작하기"
+              : "빠른 대화 시작"
         });
         navigate("/select-info", { state: { type: "fastFriend", mbti } });
         break;

--- a/src/components/button/KakaoLoginButton.tsx
+++ b/src/components/button/KakaoLoginButton.tsx
@@ -1,3 +1,5 @@
+import trackClickEvent from "@/utils/trackClickEvent";
+
 const KakaoLoginButton = () => {
   const kakaoRestApiKey = import.meta.env.VITE_KAKAO_REST_API_KEY;
   const kakaoRedirectUrl = import.meta.env.VITE_KAKAO_REDIRECT_URI;
@@ -5,6 +7,7 @@ const KakaoLoginButton = () => {
   const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${kakaoRestApiKey}&redirect_uri=${kakaoRedirectUrl}&response_type=code`;
 
   const handleClick = () => {
+    trackClickEvent("로그인/회원가입", "카카오 로그인 버튼");
     window.location.href = kakaoURL;
   };
 

--- a/src/components/button/KakaoLoginButton.tsx
+++ b/src/components/button/KakaoLoginButton.tsx
@@ -10,7 +10,7 @@ const KakaoLoginButton = () => {
   const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${kakaoRestApiKey}&redirect_uri=${kakaoRedirectUrl}&response_type=code`;
 
   const handleClick = () => {
-    trackClickEvent("로그인/회원가입", "카카오 로그인 버튼");
+    trackClickEvent("로그인/회원가입", "로그인");
     window.location.href = kakaoURL;
   };
 

--- a/src/components/button/LoginButton.tsx
+++ b/src/components/button/LoginButton.tsx
@@ -2,7 +2,7 @@ import trackClickEvent from "@/utils/trackClickEvent";
 
 const LoginButton = () => {
   const handleClick = () => {
-    trackClickEvent("홈", "로그인 버튼");
+    trackClickEvent("홈", "로그인");
   };
 
   return (

--- a/src/components/button/LoginButton.tsx
+++ b/src/components/button/LoginButton.tsx
@@ -1,8 +1,14 @@
+import trackClickEvent from "@/utils/trackClickEvent";
+
 const LoginButton = () => {
+  const handleClick = () => {
+    trackClickEvent("홈", "로그인 버튼");
+  };
+
   return (
-    <a href="/login">
-      <button className="w-[69px] h-[36px] border-[0.8px] border-gray-300 rounded-lg font-bold text-gray-600 text-md">
-      로그인
+    <a href="/login" onClick={handleClick}>
+      <button className="h-[36px] w-[69px] rounded-lg border-[0.8px] border-gray-300 text-md font-bold text-gray-600">
+        로그인
       </button>
     </a>
   );

--- a/src/components/button/RestartButton.tsx
+++ b/src/components/button/RestartButton.tsx
@@ -1,11 +1,9 @@
 import { useNavigate } from "react-router-dom";
-import trackClickEvent from "@/utils/trackClickEvent";
 
 const RestartButton = () => {
   const navigate = useNavigate();
 
   const goFirstStep = () => {
-    trackClickEvent("/MBTI 테스트 결과", "돌아가기 버튼");
     navigate("/mbti-test");
   };
 

--- a/src/components/button/RestartButton.tsx
+++ b/src/components/button/RestartButton.tsx
@@ -1,17 +1,22 @@
 import { useNavigate } from "react-router-dom";
+import trackClickEvent from "@/utils/trackClickEvent";
 
 const RestartButton = () => {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const goFirstStep = () => {
-        navigate("/mbti-test");
-    }
+  const goFirstStep = () => {
+    trackClickEvent("/MBTI 테스트 결과", "돌아가기 버튼");
+    navigate("/mbti-test");
+  };
 
-    return (
-        <button className="flex justify-center items-center bg-gray-100 rounded-lg w-[72px] h-[60px]" onClick={goFirstStep}>
-            <img src="/icon/restart.svg" alt="다시하기 버튼" width={24} height={24} />
-        </button>
-  )
-}
+  return (
+    <button
+      className="flex h-[60px] w-[72px] items-center justify-center rounded-lg bg-gray-100"
+      onClick={goFirstStep}
+    >
+      <img src="/icon/restart.svg" alt="다시하기 버튼" width={24} height={24} />
+    </button>
+  );
+};
 
 export default RestartButton;

--- a/src/components/button/ShareButton.tsx
+++ b/src/components/button/ShareButton.tsx
@@ -1,12 +1,20 @@
 import { useState } from "react";
 import ShareModal from "@/components/modal/ShareModal";
+import trackClickEvent from "@/utils/trackClickEvent";
 
 const ShareButton = () => {
   const [shareModalIsOpen, setShareModalIsOpen] = useState(false);
 
+  const handleClick = () => {
+    setShareModalIsOpen(true);
+    trackClickEvent("MBTI 테스트 결과", "공유하기 버튼");
+  };
   return (
     <>
-      <button onClick={()=>setShareModalIsOpen(true)} className="flex h-[60px] w-full items-center justify-center rounded-lg border border-primary-light bg-primary-pale font-bold text-primary-normal">
+      <button
+        onClick={handleClick}
+        className="flex h-[60px] w-full items-center justify-center rounded-lg border border-primary-light bg-primary-pale font-bold text-primary-normal"
+      >
         공유하기
       </button>
       {shareModalIsOpen && (

--- a/src/components/button/ShareButton.tsx
+++ b/src/components/button/ShareButton.tsx
@@ -1,13 +1,11 @@
 import { useState } from "react";
 import ShareModal from "@/components/modal/ShareModal";
-import trackClickEvent from "@/utils/trackClickEvent";
 
 const ShareButton = () => {
   const [shareModalIsOpen, setShareModalIsOpen] = useState(false);
 
   const handleClick = () => {
     setShareModalIsOpen(true);
-    trackClickEvent("MBTI 테스트 결과", "공유하기 버튼");
   };
   return (
     <>

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -6,7 +6,7 @@ const MainHeader = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
   const navigate = useNavigate();
 
   const handleNavigate = () => {
-    trackClickEvent("홈", "내 정보 버튼");
+    trackClickEvent("홈", "내정보");
     navigate("/my-info");
   };
 

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -1,10 +1,12 @@
 import { Link, useNavigate } from "react-router-dom";
 import LoginButton from "@/components/button/LoginButton";
+import trackClickEvent from "@/utils/trackClickEvent";
 
 const MainHeader = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
   const navigate = useNavigate();
 
   const handleNavigate = () => {
+    trackClickEvent("홈", "내 정보 버튼");
     navigate("/my-info");
   };
 

--- a/src/components/tips/TipsMenu.tsx
+++ b/src/components/tips/TipsMenu.tsx
@@ -7,22 +7,26 @@ const TipsMenu = ({
   mode: "topic" | "conversation" | "temporature";
 }) => {
   let text = "";
+  let tagElement = "";
   let imageUrl = "";
   let href = "";
 
   switch (mode) {
     case "topic":
       text = "대화 주제 추천";
+      tagElement = "대화 주제 추천";
       imageUrl = "/icon/starbubble.svg";
       href = "/chat-recommend";
       break;
     case "conversation":
       text = "대화 꿀팁";
+      tagElement = "대화 꿀팁";
       imageUrl = "/icon/lightbulb.svg";
       href = "/chat-tips";
       break;
     case "temporature":
       text = "현재 대화의 온도 측정하기";
+      tagElement = "대화의 온도";
       imageUrl = "/icon/thermometer.svg";
       href = "/chat-temporature";
       break;
@@ -31,7 +35,7 @@ const TipsMenu = ({
   }
 
   const handleClick = () => {
-    trackClickEvent("채팅방", text);
+    trackClickEvent("채팅방", tagElement);
   };
 
   return (

--- a/src/components/tips/TipsMenu.tsx
+++ b/src/components/tips/TipsMenu.tsx
@@ -1,3 +1,4 @@
+import trackClickEvent from "@/utils/trackClickEvent";
 import { Link } from "react-router-dom";
 
 const TipsMenu = ({
@@ -29,8 +30,12 @@ const TipsMenu = ({
       return;
   }
 
+  const handleClick = () => {
+    trackClickEvent("채팅방", text);
+  };
+
   return (
-    <Link to={href}>
+    <Link to={href} onClick={handleClick}>
       <div className="flex h-[56px] w-full border-t border-gray-100 bg-white px-4 py-4 hover:bg-primary-pale">
         <img src={imageUrl} alt={text} width={20} height={20} />
         <h2 className="text-2lg ml-[22px] font-medium text-gray-800">{text}</h2>

--- a/src/pages/MbtiTestIntro.tsx
+++ b/src/pages/MbtiTestIntro.tsx
@@ -2,6 +2,8 @@ import { ChangeEvent, FormEvent, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/header/Header";
 import useLayoutSize from "@/hooks/useLayoutSize";
+import trackClickEvent from "@/utils/trackClickEvent";
+
 const MbtiTestIntro = () => {
   const [name, setName] = useState("");
   const navigate = useNavigate();
@@ -59,6 +61,9 @@ const MbtiTestIntro = () => {
           <button
             type="submit"
             className="mt-[60px] h-[60px] w-[320px] rounded-lg bg-primary-normal font-bold text-white hover:opacity-80 lg:w-[460px]"
+            onClick={() =>
+              trackClickEvent("Mbti 테스트 첫 화면", "시작하기 버튼")
+            }
           >
             시작하기
           </button>

--- a/src/pages/MbtiTestIntro.tsx
+++ b/src/pages/MbtiTestIntro.tsx
@@ -61,9 +61,7 @@ const MbtiTestIntro = () => {
           <button
             type="submit"
             className="mt-[60px] h-[60px] w-[320px] rounded-lg bg-primary-normal font-bold text-white hover:opacity-80 lg:w-[460px]"
-            onClick={() =>
-              trackClickEvent("바이럴 콘텐츠 소개", "시작하기 버튼")
-            }
+            onClick={() => trackClickEvent("바이럴 콘텐츠 소개", "")}
           >
             시작하기
           </button>

--- a/src/pages/MbtiTestIntro.tsx
+++ b/src/pages/MbtiTestIntro.tsx
@@ -62,7 +62,7 @@ const MbtiTestIntro = () => {
             type="submit"
             className="mt-[60px] h-[60px] w-[320px] rounded-lg bg-primary-normal font-bold text-white hover:opacity-80 lg:w-[460px]"
             onClick={() =>
-              trackClickEvent("Mbti 테스트 첫 화면", "시작하기 버튼")
+              trackClickEvent("바이럴 콘텐츠 소개", "시작하기 버튼")
             }
           >
             시작하기

--- a/src/pages/MbtiTestQuestions.tsx
+++ b/src/pages/MbtiTestQuestions.tsx
@@ -19,8 +19,7 @@ const MbtiTestQuestions = () => {
   const { currentPage } = useMbtiTestState();
 
   useEffect(() => {
-    const pageName = `MBTI 테스트 진행중 - Step ${currentPage}`;
-    trackPageView("/mbti-progress", pageName);
+    trackPageView(`바이럴 콘텐츠 (질문 ${currentPage})`, "");
   }, [currentPage]);
 
   if (currentPage) {

--- a/src/pages/MbtiTestQuestions.tsx
+++ b/src/pages/MbtiTestQuestions.tsx
@@ -1,7 +1,10 @@
+import { useEffect } from "react";
+import { trackPageView } from "@/libs/analytics";
 import { TEST_QNA } from "@/constants/TEST_QNA";
 import MbtiAnswerButtons from "@/components/button/MbtiAnswerButtons";
 import useMbtiTestState from "@/store/useMbtiTestState";
 import Header from "@/components/header/Header";
+import Error from "@/pages/Error";
 
 interface content {
   number: number;
@@ -15,31 +18,36 @@ interface content {
 const MbtiTestQuestions = () => {
   const { currentPage } = useMbtiTestState();
 
+  useEffect(() => {
+    const pageName = `MBTI 테스트 진행중 - Step ${currentPage}`;
+    trackPageView("/mbti-progress", pageName);
+  }, [currentPage]);
+
   if (currentPage) {
     const content: content = TEST_QNA[Number(currentPage) - 1];
 
     return (
-      <div className="sm:w-[360px] md:w-[375px] lg:w-[500px] flex flex-col">
-        <Header title="상대방 MBTI 유추 테스트"/>
-        <main className="flex flex-col items-center justify-center bg-white whitespace-pre-wrap h-full ">
-        <span className="text-lg font-medium text-gray-500">
-          {content.number}/12
-        </span>
-        <h1 className="mt-[20px] text-center text-3xl font-medium whitespace-pre-wrap">
-          {content.question}
-        </h1>
-        <img
-          src={`/icon/mbti_test_${currentPage}.svg`}
-          alt="mbti 테스트 과정 이미지"
-          className="mt-10"
-        />
-        <div className="mt-[93px]">
-          <MbtiAnswerButtons content={content.answers} />
-        </div>
+      <div className="flex flex-col sm:w-[360px] md:w-[375px] lg:w-[500px]">
+        <Header title="상대방 MBTI 유추 테스트" />
+        <main className="flex h-full flex-col items-center justify-center bg-white whitespace-pre-wrap ">
+          <span className="text-lg font-medium text-gray-500">
+            {content.number}/12
+          </span>
+          <h1 className="mt-[20px] text-center text-3xl font-medium whitespace-pre-wrap">
+            {content.question}
+          </h1>
+          <img
+            src={`/icon/mbti_test_${currentPage}.svg`}
+            alt="mbti 테스트 과정 이미지"
+            className="mt-10"
+          />
+          <div className="mt-[93px]">
+            <MbtiAnswerButtons content={content.answers} />
+          </div>
         </main>
       </div>
     );
-  } else return <div>404 error</div>;
+  } else return <Error statusCode="404" />;
 };
 
 export default MbtiTestQuestions;

--- a/src/pages/MbtiTestResult.tsx
+++ b/src/pages/MbtiTestResult.tsx
@@ -1,4 +1,3 @@
-import { MouseEvent } from "react";
 import { MBTI_RESULT_INFO } from "@/constants/MBTI_RESULT_INFO";
 import ShareButton from "@/components/button/ShareButton";
 import RestartButton from "@/components/button/RestartButton";

--- a/src/utils/trackClickEvent.ts
+++ b/src/utils/trackClickEvent.ts
@@ -1,0 +1,10 @@
+import { trackEvent } from "@/libs/analytics";
+
+const trackClickEvent = (page: string, element: string) => {
+  trackEvent("Click", {
+    page: page,
+    element: element
+  });
+};
+
+export default trackClickEvent;


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- [ ] MBTI test 관련 페이지 trackePath 추가 -> prgress만 페이지 컴포넌트에서 관리(전역 상태에 따라 SPA로 동작하도록 구현했기 떄문)
- [ ] Chat tips 관련 페이지 trackedPath 추가 
- [ ] [Notion - GA 태깅](https://www.notion.so/GA-1c8c7ea2eddb800d9214c5719f2dc216?pvs=25) 정준영 파트 Click 이벤트 할당 

### :1234: #216 

### ❗️PR Point
- page와 element를 문자열로 받아서 trackEvent("Click") 함수를 호출해주는 trackClickEvent util 함수를 만들어 사용했습니다.

### 📸 스크린샷
- 없음