### PR TITLE
fix: 친구 저장하기 버튼 문구, navigate 수정 및 ga element 변경

### DIFF
--- a/src/pages/SelectInfo.tsx
+++ b/src/pages/SelectInfo.tsx
@@ -56,6 +56,9 @@ const SelectInfo = () => {
       ? testResultMBTI
       : undefined;
 
+  const confirmButtonText =
+    type === "fastFriend" ? "대화 시작하기" : "친구 저장하기";
+
   const [selectedMBTI, setSelectedMBTI] = useState<{
     [key: string]: string | null;
   }>({
@@ -152,7 +155,7 @@ const SelectInfo = () => {
     setTimeout(() => setToastMessage(null), 3000);
   };
 
-  const handleStartChat = async () => {
+  const handleConfirmButton = async () => {
     const isMBTIComplete = Object.values(selectedMBTI).every(
       (val) => val !== null
     );
@@ -201,16 +204,9 @@ const SelectInfo = () => {
       if (type === "virtualFriend" && isVirtualFriendResponse(responseData)) {
         trackEvent("Click", {
           page: "친구 저장",
-          element: "대화 시작하기"
+          element: "친구 저장하기"
         });
-        navigate("/chat", {
-          state: {
-            mbti,
-            mode: type,
-            id: responseData.conversationId,
-            name: responseData.virtualFriendName
-          }
-        });
+        navigate("/");
       } else if (type === "fastFriend" && typeof responseData === "number") {
         trackEvent("Click", {
           page: "빠른 대화 설정",
@@ -372,9 +368,9 @@ const SelectInfo = () => {
         {/* 대화 시작 버튼 */}
         <button
           className="my-[22px] h-[60px] w-full rounded-[8px] bg-primary-normal font-bold text-white"
-          onClick={handleStartChat}
+          onClick={handleConfirmButton}
         >
-          대화 시작하기
+          {confirmButtonText}
         </button>
       </div>
     </div>


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용 (QA 이슈)
- [x]  친구 저장하기 버튼 문구 수정 (대화 시작하기 -> 친구 저장하기) 
- [x] 친구 저장하기 navigate 수정 (/chat -> /)
- [x] 친구 저장하기 버튼 click event GA element 변경 (대화 시작하기 -> 친구 저장하기)

### :1234: 이슈 번호
- #240 

### ❗️PR Point
- Flow: https://www.figma.com/design/fvTo6KUgDe1rzn1aw2vvre/-MBTIPS--WEB-%EC%A0%9C%ED%92%88?node-id=175-6156&t=XJ59Pn2hgZL1UitZ-0

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/28848d27-1f19-415d-93e2-b6123da2de2a)
