### PR TITLE
fix: "로그인 세션이 만료되었습니다." 반복 팝업 되는 문제 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,7 @@ const App = () => {
 
   useEffect(() => {
     initGA();
-    if (parsedAuth) checkSession();
+    if (parsedAuth.accessToken) checkSession();
   }, []);
 
   return (


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- [x] App.tsx -> parsedAuth에 accessToken이 null일 때에만 checkSession 함수가 호출되도록 변경했습니다.

### :1234: #245 

### ❗️PR Point
- 없음

### 📸 스크린샷
https://github.com/user-attachments/assets/41d72c10-c714-4472-a08e-19f63db731cd