### PR TITLE
fix : App.tsx checkSession 호출 이전 조건문에 parsedAuth 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,7 @@ const App = () => {
 
   useEffect(() => {
     initGA();
-    if (parsedAuth.accessToken) checkSession();
+    if (parsedAuth && parsedAuth.accessToken) checkSession();
   }, []);
 
   return (


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- [x] checkSession() 호출 이전에 조건문에 parsedAuth를 추가해주어 parsedAuth가 null일 때 accessToken을 참조하는 일이 없도록 해줍니다.

### :1234: #255 

### ❗️PR Point
- 없음

### 📸 스크린샷
- 없음