### PR TITLE
fix: header 시멘틱 태그 변경, div 삭제에 따른 전반적인 코드 수정

### DIFF
--- a/src/components/CenteredLayout.tsx
+++ b/src/components/CenteredLayout.tsx
@@ -6,7 +6,9 @@ interface CenteredLayoutProps {
 
 const CenteredLayout = ({ children }: CenteredLayoutProps) => (
   <div className="flex min-h-screen w-screen justify-center bg-gray-50">
-    <div className="flex w-full justify-center bg-gray-50">{children}</div>
+    <div className="flex w-full flex-col bg-white lg:w-[500px] ">
+      {children}
+    </div>
   </div>
 );
 

--- a/src/components/ChatActionBar.tsx
+++ b/src/components/ChatActionBar.tsx
@@ -1,7 +1,6 @@
 import { ChangeEvent, KeyboardEvent } from "react";
 import ToggleChatTipsButton from "@/components/button/ToggleChatTipsButton";
 import MessageInput from "@/components/input/MessageInput";
-import TipsMenuContainer from "@/components/tips/TipsMenuContainer";
 
 interface ChatActionProps {
   isOpen: boolean;
@@ -21,7 +20,7 @@ const ChatActionBar = ({
   onSend
 }: ChatActionProps) => {
   return (
-    <div className="flex h-[68px] w-full items-center justify-center border-t border-gray-100 bg-white">
+    <section className="flex h-[68px] w-full items-center justify-center border-t border-gray-100 bg-white">
       <ToggleChatTipsButton isOpen={isOpen} setIsOpen={setIsOpen} />
       <MessageInput value={value} onChange={onChange} onKeyUp={onKeyUp} />
       <img
@@ -32,7 +31,7 @@ const ChatActionBar = ({
         width={40}
         height={40}
       />
-    </div>
+    </section>
   );
 };
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import SubHeader from "@/components/header/SubHeader";
 import MainHeader from "@/components/header/MainHeader";
@@ -8,14 +7,12 @@ type HeaderProps = {
   title?: string;
   showPreviousIcon?: boolean;
   showShareIcon?: boolean;
-  children?: ReactNode;
 };
 
 const Header = ({
   title = "",
   showPreviousIcon = true,
-  showShareIcon = true,
-  children
+  showShareIcon = true
 }: HeaderProps) => {
   const { pathname } = useLocation();
   const { isLoggedIn } = useAuthStore();
@@ -23,7 +20,7 @@ const Header = ({
 
   return (
     <>
-      <div className="fixed z-50 w-[360px] bg-white md:w-[375px] lg:w-[500px]">
+      <header className="fixed top-0 z-50 w-[360px] bg-white md:w-[375px] lg:w-[500px]">
         {isHomepage ? (
           <MainHeader isLoggedIn={isLoggedIn} />
         ) : (
@@ -33,9 +30,7 @@ const Header = ({
             showShareIcon={showShareIcon}
           />
         )}
-      </div>
-
-      <div className="pt-14">{children}</div>
+      </header>
     </>
   );
 };

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -11,7 +11,7 @@ const MainHeader = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
   };
 
   return (
-    <header className="flex h-[56px] w-full items-center justify-between bg-white pl-5">
+    <div className="flex h-[56px] w-full items-center justify-between bg-white pl-5">
       <Link to="/" className="flex items-center">
         <img
           src="/public/icon/mbtipslogo.svg"
@@ -32,7 +32,7 @@ const MainHeader = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
           onClick={handleNavigate}
         />
       )}
-    </header>
+    </div>
   );
 };
 

--- a/src/components/header/SubHeader.tsx
+++ b/src/components/header/SubHeader.tsx
@@ -56,7 +56,7 @@ const SubHeader = ({
 
   return (
     <>
-      <header className="relative flex h-[56px] w-full items-center justify-between border-b border-gray-100 bg-white">
+      <div className="relative flex h-[56px] w-full items-center justify-between border-b border-gray-100 bg-white">
         {showPreviousIcon && (
           <img
             src="/public/icon/arrow_left.svg"
@@ -85,7 +85,7 @@ const SubHeader = ({
             />
           </button>
         )}
-      </header>
+      </div>
 
       {isLeaveChatModalOpen && (
         <ActionConfirmModal

--- a/src/components/tips/TipsMenuContainer.tsx
+++ b/src/components/tips/TipsMenuContainer.tsx
@@ -8,11 +8,11 @@ const TipsMenuContainer = ({
   mbti: string;
 }) => {
   return (
-    <>
+    <section>
       <TipsMenu mode="topic" mbti={mbti} />
       <TipsMenu mode="conversation" mbti={mbti} />
       <TipsMenu mode="temperature" conversationId={conversationId} />
-    </>
+    </section>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,8 @@ body {
 }
 
 main {
+  margin-top: 56px;
+
   @media screen and (min-width: 360px) {
     background-color: white;
     font-size: 14px;

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -143,10 +143,9 @@ const Chat = () => {
         <meta property="twitter:description" content={`${mbti}와의 대화창`} />
       </Helmet>
 
-      <div className="flex h-screen w-[360px] flex-col bg-white md:w-[375px] lg:w-[500px]">
-        <Header title={chatTitle} showShareIcon={false}/>
-
-        <div className="flex-1 space-y-4 overflow-y-auto px-[20px] pt-6">
+      <Header title={chatTitle} showShareIcon={false} />
+      <main>
+        <section className="h-[calc(100vh-124px)] flex-1 space-y-4 overflow-y-auto px-[20px] pt-6">
           <IntroGuide />
           {/* 메시지 리스트 */}
           {messages.map((msg, idx) => (
@@ -173,7 +172,7 @@ const Chat = () => {
           ))}
 
           <div ref={bottomRef} />
-        </div>
+        </section>
 
         <ChatActionBar
           isOpen={isOpen}
@@ -185,7 +184,7 @@ const Chat = () => {
         />
 
         {isOpen && <TipsMenuContainer conversationId={id} mbti={mbti} />}
-      </div>
+      </main>
     </>
   );
 };

--- a/src/pages/ChatRecommend.tsx
+++ b/src/pages/ChatRecommend.tsx
@@ -26,22 +26,20 @@ const ChatRecommend = () => {
         <meta property="twitter:description" content="대화 주제 추천" />
       </Helmet>
 
-      <div>
-        <Header
-          title="대화 주제 추천"
-          showPreviousIcon={true}
-          showShareIcon={true}
+      <Header
+        title="대화 주제 추천"
+        showPreviousIcon={true}
+        showShareIcon={true}
+      />
+      <main className="mx-auto flex h-screen flex-col px-5 py-6">
+        <img
+          src={mbtiImage}
+          alt="mbti 이미지"
+          className="h-auto w-full rounded-2xl"
         />
-        <main className="mx-auto flex h-screen flex-col px-5 py-6">
-          <img
-            src={mbtiImage}
-            alt="mbti 이미지"
-            className="h-auto w-full rounded-2xl"
-          />
-          <h1 className="mt-9 text-xl font-bold">{title}</h1>
-          <span className="mt-6 whitespace-pre-wrap">{description}</span>
-        </main>
-      </div>
+        <h1 className="mt-9 text-xl font-bold">{title}</h1>
+        <span className="mt-6 whitespace-pre-wrap">{description}</span>
+      </main>
     </>
   );
 };

--- a/src/pages/ChatTemperature.tsx
+++ b/src/pages/ChatTemperature.tsx
@@ -39,32 +39,26 @@ const ChatTemperature = () => {
         <meta property="twitter:description" content="대화의 온도" />
       </Helmet>
 
-      <div>
-        <Header
-          title="대화 온도"
-          showPreviousIcon={true}
-          showShareIcon={true}
+      <Header title="대화 온도" showPreviousIcon={true} showShareIcon={true} />
+      <main className="mx-auto flex h-screen flex-col px-5 py-6">
+        <img
+          src={"/image/image_온도.png"}
+          alt="mbti 온도 이미지"
+          className="h-auto w-full rounded-2xl"
         />
-        <main className="mx-auto flex h-screen flex-col px-5 py-6">
-          <img
-            src={"/image/image_온도.png"}
-            alt="mbti 온도 이미지"
-            className="h-auto w-full rounded-2xl"
-          />
-          <h1 className="mt-9 text-xl font-bold">
-            방금까지 나눈 대화로 온도를 측정했어요!
-          </h1>
-          {temperature ? (
-            <span className="mt-6 whitespace-pre-wrap">
-              현재까지 나눈 대화의 온도는 {temperature}도에요
-            </span>
-          ) : (
-            <span className="mt-6 whitespace-pre-wrap">
-              ...대화의 온도를 불러오는 중
-            </span>
-          )}
-        </main>
-      </div>
+        <h1 className="mt-9 text-xl font-bold">
+          방금까지 나눈 대화로 온도를 측정했어요!
+        </h1>
+        {temperature ? (
+          <span className="mt-6 whitespace-pre-wrap">
+            현재까지 나눈 대화의 온도는 {temperature}도에요
+          </span>
+        ) : (
+          <span className="mt-6 whitespace-pre-wrap">
+            ...대화의 온도를 불러오는 중
+          </span>
+        )}
+      </main>
     </>
   );
 };

--- a/src/pages/ChatTips.tsx
+++ b/src/pages/ChatTips.tsx
@@ -26,22 +26,16 @@ const ChatTips = () => {
         <meta property="twitter:description" content="대화 꿀팁" />
       </Helmet>
 
-      <div>
-        <Header
-          title="대화 꿀팁"
-          showPreviousIcon={true}
-          showShareIcon={true}
+      <Header title="대화 꿀팁" showPreviousIcon={true} showShareIcon={true} />
+      <main className="mx-auto flex h-screen flex-col px-5 py-6">
+        <img
+          src={mbtiImage}
+          alt="mbti 이미지"
+          className="h-auto w-full rounded-2xl"
         />
-        <main className="mx-auto flex h-screen flex-col px-5 py-6">
-          <img
-            src={mbtiImage}
-            alt="mbti 이미지"
-            className="h-auto w-full rounded-2xl"
-          />
-          <h1 className="mt-9 text-xl font-bold">{title}</h1>
-          <span className="mt-6 whitespace-pre-wrap">{description}</span>
-        </main>
-      </div>
+        <h1 className="mt-9 text-xl font-bold">{title}</h1>
+        <span className="mt-6 whitespace-pre-wrap">{description}</span>
+      </main>
     </>
   );
 };

--- a/src/pages/Content.tsx
+++ b/src/pages/Content.tsx
@@ -71,7 +71,7 @@ const Content = () => {
       <div className="flex w-[360px] flex-col bg-white md:w-[375px] lg:w-[500px]">
         <Header title="콘텐츠" />
 
-        <div className="flex flex-col gap-[36px] px-5 py-5">
+        <main className="flex flex-col gap-[36px] px-5 py-5">
           {/* 상단 배너 */}
           <div className="relative overflow-hidden rounded-[16px] bg-gray-100">
             <picture>
@@ -104,7 +104,7 @@ const Content = () => {
           >
             대화 시작하기
           </button>
-        </div>
+        </main>
       </div>
     </>
   );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -34,7 +34,7 @@ const Login = () => {
         <meta property="twitter:description" content="로그인/회원가입" />
       </Helmet>
 
-      <main className="flex h-[812px] flex-col items-center bg-white">
+      <main className="!mt-0 flex h-[812px] flex-col items-center bg-white">
         <img
           src={isPC ? "/image/login/banner_lg.png" : "/image/login/banner.png"}
           alt="로그인 페이지 이미지"

--- a/src/pages/MbtiTestQuestions.tsx
+++ b/src/pages/MbtiTestQuestions.tsx
@@ -45,25 +45,23 @@ const MbtiTestQuestions = () => {
           />
         </Helmet>
 
-        <div className="flex flex-col sm:w-[360px] md:w-[375px] lg:w-[500px]">
-          <Header title="상대방 MBTI 유추 테스트" />
-          <main className="flex h-full flex-col items-center justify-center bg-white whitespace-pre-wrap ">
-            <span className="text-lg font-medium text-gray-500">
-              {content.number}/12
-            </span>
-            <h1 className="mt-[20px] text-center text-3xl font-medium whitespace-pre-wrap">
-              {content.question}
-            </h1>
-            <img
-              src={`/icon/mbti_test_${currentPage}.svg`}
-              alt="mbti 테스트 과정 이미지"
-              className="mt-10"
-            />
-            <div className="mt-[93px]">
-              <MbtiAnswerButtons content={content.answers} />
-            </div>
-          </main>
-        </div>
+        <Header title="상대방 MBTI 유추 테스트" />
+        <main className="flex h-full flex-col items-center justify-center bg-white whitespace-pre-wrap ">
+          <span className="text-lg font-medium text-gray-500">
+            {content.number}/12
+          </span>
+          <h1 className="mt-[20px] text-center text-3xl font-medium whitespace-pre-wrap">
+            {content.question}
+          </h1>
+          <img
+            src={`/icon/mbti_test_${currentPage}.svg`}
+            alt="mbti 테스트 과정 이미지"
+            className="mt-10"
+          />
+          <div className="mt-[60px]">
+            <MbtiAnswerButtons content={content.answers} />
+          </div>
+        </main>
       </>
     );
   } else return <Error statusCode="404" />;

--- a/src/pages/MbtiTestResult.tsx
+++ b/src/pages/MbtiTestResult.tsx
@@ -6,7 +6,6 @@ import RestartButton from "@/components/button/RestartButton";
 import ChatStartButton from "@/components/button/ChatStartButton";
 import useLayoutSize from "@/hooks/useLayoutSize";
 import Header from "@/components/header/Header";
-import { useParams } from "react-router-dom";
 
 const MbtiTestResult = () => {
   const { mbti } = useParams();

--- a/src/pages/MyInfo.tsx
+++ b/src/pages/MyInfo.tsx
@@ -75,39 +75,41 @@ const MyInfo = () => {
     <div className="relative flex w-[360px] flex-col bg-white md:w-[375px] lg:w-[500px]">
       <Header title="내 정보" showShareIcon={false} />
 
-      <ul className="mt-[10px] flex flex-col justify-between gap-[20px]">
-        {menuItems.map((item, index) => (
-          <li
-            key={index}
-            className="flex h-[56px] cursor-pointer items-center justify-between px-5 py-4 hover:bg-gray-50"
-            onClick={item.onClick}
-          >
-            <span className="text-base font-medium text-gray-900">
-              {item.label}
-            </span>
-            <img
-              src="/icon/arrow_right.svg"
-              alt="arrow"
-              className="h-6 w-6 text-gray-600"
-            />
-          </li>
-        ))}
-      </ul>
+      <main>
+        <ul className="mt-[10px] flex flex-col justify-between gap-[20px]">
+          {menuItems.map((item, index) => (
+            <li
+              key={index}
+              className="flex h-[56px] cursor-pointer items-center justify-between px-5 py-4 hover:bg-gray-50"
+              onClick={item.onClick}
+            >
+              <span className="text-base font-medium text-gray-900">
+                {item.label}
+              </span>
+              <img
+                src="/icon/arrow_right.svg"
+                alt="arrow"
+                className="h-6 w-6 text-gray-600"
+              />
+            </li>
+          ))}
+        </ul>
 
-      {modalType && (modalType === "logout" || modalType === "withdraw") && (
-        <ActionConfirmModal
-          title={alertConfig[modalType].title}
-          message={alertConfig[modalType].message}
-          cancelText={alertConfig[modalType].cancelText}
-          confirmText={alertConfig[modalType].confirmText}
-          onCancel={handleCancel}
-          onConfirm={handleConfirm}
-        />
-      )}
+        {modalType && (modalType === "logout" || modalType === "withdraw") && (
+          <ActionConfirmModal
+            title={alertConfig[modalType].title}
+            message={alertConfig[modalType].message}
+            cancelText={alertConfig[modalType].cancelText}
+            confirmText={alertConfig[modalType].confirmText}
+            onCancel={handleCancel}
+            onConfirm={handleConfirm}
+          />
+        )}
 
-      {modalType && (modalType === "terms" || modalType === "privacy") && (
-        <TermsAndPrivacyModal mode={modalType} closeModal={handleCancel} />
-      )}
+        {modalType && (modalType === "terms" || modalType === "privacy") && (
+          <TermsAndPrivacyModal mode={modalType} closeModal={handleCancel} />
+        )}
+      </main>
     </div>
   );
 };

--- a/src/pages/SelectInfo.tsx
+++ b/src/pages/SelectInfo.tsx
@@ -250,9 +250,9 @@ const SelectInfo = () => {
         />
       </Helmet>
 
-      <div className="flex w-[360px] flex-col bg-white md:w-[375px] lg:w-[500px]">
-        <Header title={headerTitle} showShareIcon={false} />
+      <Header title={headerTitle} showShareIcon={false} />
 
+      <main>
         <div className="mx-auto w-[320px]">
           {/* MBTI 선택 */}
           <div className="mb-[40px] pt-[48px]">
@@ -397,7 +397,7 @@ const SelectInfo = () => {
             {confirmButtonText}
           </button>
         </div>
-      </div>
+      </main>
     </>
   );
 };


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- [x] Header.tsx에 margin-top 14px을 주던 div를 삭제했고, 이를 index.css에 main에 주었습니다. 
- [x] 모든 페이지에서 Header 아래로 오는 부분은 본문 영역으로 판단해, main 태그로 감싸주었습니다.
- [x] Header.tsx에 가장 바깥 div를 header로 바꾸고 안에 있는 MainHeader, SubHeader를 div로 바꾸었습니다.
- [x] 몇개의 페이지에서 중복되는 레이아웃 div가 있어 삭제하고 ContentLayout 컴포넌트에 자식 div에 style을 조금 수정했습니다. 수정 이후에도 기존과 동일한 ui로 보이는지까지 모두 확인했습니다.
- [x] Chat 페이지에서 div를 section으로 나누는게 좋을 것 같아 section으로 시멘틱 태그를 부여해주었습니다.

### :1234: #267 

### ❗️PR Point
- 없음

### 📸 스크린샷
