### PR TITLE
fix: useParams import문 제거

### DIFF
--- a/src/pages/MbtiTestResult.tsx
+++ b/src/pages/MbtiTestResult.tsx
@@ -6,7 +6,6 @@ import RestartButton from "@/components/button/RestartButton";
 import ChatStartButton from "@/components/button/ChatStartButton";
 import useLayoutSize from "@/hooks/useLayoutSize";
 import Header from "@/components/header/Header";
-import { useParams } from "react-router-dom";
 
 const MbtiTestResult = () => {
   const { mbti } = useParams();


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- [x] MbtiTestResult.tsx에서 두번 import된 useParams를 제거해주었습니다.

### :1234: #269 

### ❗️PR Point
- 없음

### 📸 스크린샷
- 없음